### PR TITLE
rt #98029 - Missing dependency CGI

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,7 @@ abstract = Perl module to use HTML-like templating language
 match = ^file_cache/*
 
 [Prereqs]
+CGI          = 0
 Carp         = 0
 File::Spec   = 0.82
 Digest::MD5  = 0


### PR DESCRIPTION
Thank you for your work on this module.
This short pull request resolves the issue where CGI is no longer core as of 5.20:

https://rt.cpan.org/Public/Bug/Display.html?id=98029
