### PR TITLE
Tell PAUSE not to index the inner HTML::Template::* packages

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@
     - Added CGI.pm as a dependency, needed now that it's no longer in core.
       [Martin McGrath, Steve Bertrand]
     - Tell PAUSE not to index the inner HTML::Template::* packages
+    - Include a META.json in releases
 
 2.95 Mon Oct 21 2013
     - Added support for "none" for default_escape [Mark Stosberg]

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@
     - Fixed typos in documentation [David Steinbrunner, Steve Kemp]
     - Added CGI.pm as a dependency, needed now that it's no longer in core.
       [Martin McGrath, Steve Bertrand]
+    - Tell PAUSE not to index the inner HTML::Template::* packages
 
 2.95 Mon Oct 21 2013
     - Added support for "none" for default_escape [Mark Stosberg]

--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,17 @@ Digest::MD5  = 0
 Scalar::Util = 0
 CGI          = 0
 
+[MetaNoIndex]
+package = HTML::Template::COND
+package = HTML::Template::DEFAULT
+package = HTML::Template::ESCAPE
+package = HTML::Template::JSESCAPE
+package = HTML::Template::LOOP
+package = HTML::Template::NOOP
+package = HTML::Template::PRINTSCALAR
+package = HTML::Template::URLESCAPE
+package = HTML::Template::VAR
+
 [Prereqs / TestRequires]
 File::Temp   = 0
 Test::More   = 0

--- a/dist.ini
+++ b/dist.ini
@@ -33,6 +33,8 @@ package = HTML::Template::VAR
 File::Temp   = 0
 Test::More   = 0
 
+[MetaJSON]
+
 [MetaResources]
 bugtracker.web  = https://rt.cpan.org/Public/Dist/Display.html?Name=HTML-Template
 repository.url  = git://github.com/mpeters/html-template.git


### PR DESCRIPTION
Hi Michael,

This PR follows up from my email about a permissions conflict: it tells PAUSE not to index the inner packages.

Also updated `dist.ini` so that a `META.json` file will be included in releases.

Cheers,
Neil
