### PR TITLE
Added [MetaJSON] to dist.ini so releases will include a META.json file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 2.98 In development.
     - Added Unicode tests [Vytas Dauksa]
+    - Added [MetaJSON] to dist.ini so releases will include a META.json file
 
 2.97 Thu May 18 2017
     - Change internal module name HTML::Template::DEFAULT to

--- a/dist.ini
+++ b/dist.ini
@@ -29,6 +29,8 @@ repository.url  = git://github.com/mpeters/html-template.git
 repository.web  = https://github.com/mpeters/html-template
 repository.type = git
 
+[MetaJSON]
+
 [VersionFromModule]
 
 [PodSyntaxTests]


### PR DESCRIPTION
Hi,

This is a small PR that just adds [MetaJSON] to the dist.ini file, so that future releases will have a `META.json` file as well as a `META.yml` file. The JSON file has better fidelity of dependency information.

Cheers,
Neil